### PR TITLE
Fix ATOM feed links

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -18,7 +18,7 @@ layout: null
  {% for post in site.posts %}
  <entry>
    <title>{{ post.title }}</title>
-   <link href="{{ site.url }}{{ site.baseurl }}{{ post.url }}"/>
+   <link href="{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>{{ site.url }}{{ post.id }}</id>
    <content type="html">{{ post.content | xml_escape }}</content>


### PR DESCRIPTION
Currently, atom feed generates links with superfluous `/`, eg. `http://blog.piston.rs//2015/05/09/benchmark-mode/` which breaks Disqus.
This change changes atom links to relative (eg. `/2015/05/09/benchmark-mode/`. This seem to fix the problem but I don't think it's the right solution (different `site.baseurl` will probably break it).
